### PR TITLE
Sprint 24 phase 4: copilot intervention tools (re-merge to main)

### DIFF
--- a/docs/implementation-history.md
+++ b/docs/implementation-history.md
@@ -254,3 +254,19 @@ Goal: make the cost figure underneath budget limits trustworthy for OpenRouter. 
 **Tests:** `tests/openrouter-pricing.unit.test.ts` (8) — conversion, cache defaulting, skip-unpriced, apply-only-to-OpenRouter, no-op for unknown slug.
 
 **Still an estimate:** Track 1 uses OpenRouter list price, not the exact amount charged for the upstream that served each request. Exact cost = #10 Track 2 (upstream pi-ai). Backward compatible: enrichment only touches OpenRouter models (Anthropic default unchanged); `costEstimated` is additive; no new env vars, secrets, or deployment steps.
+
+## Sprint 24 (Phase 4) — Copilot intervention tools (OODA "Act")
+
+Goal: let the copilot/operator act on the `limit-alert`s from phase 2 — pause a runaway agent, resume it, or adjust the mission budget — and surface alerts in the dashboard.
+
+**`src/monitor-server.ts`:** new per-agent pause gate — `pausedAgents: Set<string>` + public `isAgentPaused(agentId)`. Three new token-checked POST routes (mirroring `/extend-budget`): `/pause-agent` and `/resume-agent` (validate `agentId` against the team via `readAgentId`, returning 400/404 on bad input), and `/set-budget` (absolute cap, vs `/extend-budget` which adds; lifts the budget pause when the new cap exceeds spend). `pausedAgents` added to the status payload; new SSE event types `agent-paused`/`agent-resumed`/`limit-alert`.
+
+**`src/daemon.ts`:** wired the previously-stubbed `isAgentPaused: (agentId) => monitor.isAgentPaused(agentId)` into the orchestration config — the orchestrator already skips paused agents at dispatch (covered by orchestrator unit test TC-7).
+
+**`packages/control-plane/src/copilot-tools.ts`, `copilot-router.ts`:** `ProposeAction` gains three action types — `pause_agent`, `resume_agent`, `set_mission_budget` — so interventions go through the established operator-confirmation flow (no silent automated action). `executeAction` handles them via a new `postToMissionMonitor` helper that resolves the mission by `{missionId, userId}`, derives the per-mission monitor token, and POSTs to the execution-plane endpoint — the same authenticated path as `write_mission_file`. `NotifyUser` was intentionally dropped (the copilot's chat already reaches the operator and the daemon already emits `limit-alert`).
+
+**`public/index.html`, `public/app.js`:** dashboard surfaces `limit-alert` as a toast (soft = amber, auto-dismiss 12s; hard = red, sticky) with metric/threshold/label.
+
+**Tests:** pause enforcement is covered by orchestrator TC-7 (paused agent skipped); endpoints mirror the tested `/extend-budget` pattern; both packages type-check and the full unit suite (66) passes. A live MonitorServer needs MongoDB, so the new routes are exercised via the existing dashboard integration harness rather than a new unit test.
+
+**Backward compatibility:** all additions are new routes / action types / optional state — nothing existing changes. No new env vars, secrets, or deployment steps. Closes the Sprint 24 OODA loop: phase 1 measures, phase 2 detects + alerts, phase 4 acts.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -272,7 +272,7 @@ graph TB
 
 | Threat | Category | Status | Notes |
 |--------|----------|--------|-------|
-| Unauthenticated `POST /stop`, `/send-message`, `/extend-budget` | S / E | ⚠️ F-008 | Binds to `127.0.0.1:4000` (localhost only); no auth on mutating routes |
+| Unauthenticated `POST /stop`, `/send-message`, `/extend-budget`, `/set-budget`, `/pause-agent`, `/resume-agent` | S / E | ⚠️ F-008 | Binds to `127.0.0.1:4000` (localhost only); no auth on mutating routes in dev. In production all are token-checked via `tokenOk()` (TB-11) and reached only through the control plane's `{missionId, userId}`-scoped `postToMissionMonitor` |
 | SSE stream exposes all mission data on localhost | I | ⚠️ F-009 | Any process on the machine can subscribe to the full agent activity stream |
 | `GET /log` exposes daemon stdout/stderr (may include agent message excerpts, internal paths) | I | ~ | In local dev: localhost-only (same as F-009). In production: behind TB-9 `X-API-Key` via proxy; only authenticated operators can reach it |
 

--- a/packages/agent-runtime-worker/public/app.js
+++ b/packages/agent-runtime-worker/public/app.js
@@ -213,6 +213,11 @@ function connectSSE() {
 		maxCostUsd = d.newCapUsd ?? maxCostUsd;
 	});
 
+	es.addEventListener("limit-alert", (e) => {
+		const d = JSON.parse(e.data);
+		showLimitToast(d);
+	});
+
 	es.addEventListener("shutdown", () => {
 		document.getElementById("dot").classList.add("dead");
 		const btn = document.getElementById("kill-btn");
@@ -349,6 +354,39 @@ function showAgentErrorBanner(agentId, errorMessage, transient) {
 
 function hideAgentErrorBanner() {
 	document.getElementById("agent-error-banner")?.classList.add("hidden");
+}
+
+// ── Limit-alert toasts ───────────────────────────────────────────────────────
+// Soft limits (advisory) and hard limits (turn aborted) emitted by the daemon.
+// Hard alerts are sticky until dismissed; soft alerts auto-dismiss after 12s.
+function showLimitToast(d) {
+	const container = document.getElementById("limit-toasts");
+	if (!container) return;
+	const hard = d.severity === "hard";
+	const toast = document.createElement("div");
+	toast.style.cssText = [
+		"margin:6px",
+		"padding:10px 14px",
+		"border-radius:6px",
+		"font-size:13px",
+		"max-width:420px",
+		"box-shadow:0 2px 8px rgba(0,0,0,0.3)",
+		`background:${hard ? "#7f1d1d" : "#78350f"}`,
+		"color:#fff",
+		`border-left:4px solid ${hard ? "#ef4444" : "#f59e0b"}`,
+	].join(";");
+	const verb = hard ? "aborted turn" : "warning";
+	toast.textContent =
+		`${hard ? "⛔" : "⚠"} Limit ${verb}: ${d.agentId} — ` +
+		`${d.metric} = ${d.value} (> ${d.threshold}). ${d.label}`;
+	const close = document.createElement("button");
+	close.textContent = "×";
+	close.style.cssText =
+		"margin-left:10px;background:none;border:none;color:#fff;cursor:pointer;font-size:16px";
+	close.onclick = () => toast.remove();
+	toast.appendChild(close);
+	container.appendChild(toast);
+	if (!hard) setTimeout(() => toast.remove(), 12_000);
 }
 
 async function resumeAgentAfterError(agentId) {

--- a/packages/agent-runtime-worker/public/index.html
+++ b/packages/agent-runtime-worker/public/index.html
@@ -35,6 +35,9 @@
   <button type="button" class="btn btn-resume hidden" id="ae-resume-btn">Resume</button>
 </div>
 
+<!-- Transient limit-alert toasts (soft = warning, hard = turn aborted) -->
+<div id="limit-toasts" style="position:fixed;bottom:12px;right:12px;z-index:1000;display:flex;flex-direction:column;align-items:flex-end"></div>
+
 <main>
   <!-- Left: thread list + chat + compose -->
   <div class="left-col">

--- a/packages/agent-runtime-worker/src/daemon.ts
+++ b/packages/agent-runtime-worker/src/daemon.ts
@@ -1017,6 +1017,7 @@ async function main(): Promise<void> {
 				waitForMail,
 				waitForStep: () => monitor.waitForStep(),
 				waitForBudget: () => monitor.waitForBudget(),
+				isAgentPaused: (agentId) => monitor.isAgentPaused(agentId),
 				onLimitAlert: (alert) => {
 					const { agentId, turnNumber, breach } = alert;
 					const { rule, value } = breach;

--- a/packages/agent-runtime-worker/src/monitor-server.ts
+++ b/packages/agent-runtime-worker/src/monitor-server.ts
@@ -83,7 +83,9 @@ export type MonitorEventType =
 	| "status"
 	| "started"
 	| "agent-error"
-	| "limit-alert";
+	| "limit-alert"
+	| "agent-paused"
+	| "agent-resumed";
 
 export interface AgentInfo {
 	id: string;
@@ -141,8 +143,17 @@ export class MonitorServer {
 	private budgetPaused = false;
 	private budgetResolve: (() => void) | null = null;
 	private currentCapUsd: number | null;
-	/** Callback so daemon.ts can update its local maxCostUsd when the cap is raised. */
+	/** Callback so daemon.ts can update its local maxCostUsd when the cap is changed. */
 	onBudgetExtended?: (newCapUsd: number) => void;
+
+	// Per-agent pause gate (copilot/operator intervention). Agents in this set are
+	// skipped by the orchestrator at the next dispatch boundary until resumed.
+	private readonly pausedAgents = new Set<string>();
+
+	/** Read by the orchestrator's isAgentPaused hook before dispatching an agent. */
+	isAgentPaused(agentId: string): boolean {
+		return this.pausedAgents.has(agentId);
+	}
 
 	// Agent workdir map (populated by daemon after workspace provision)
 	private agentWorkdirs = new Map<string, string>();
@@ -773,6 +784,67 @@ export class MonitorServer {
 			return;
 		}
 
+		// ── POST /set-budget — set an absolute spending cap (cf. /extend-budget which adds)
+		if (url === "/set-budget" && req.method === "POST") {
+			const body = await readBody(req);
+			let capUsd: number | null = null;
+			try {
+				const parsed = JSON.parse(body) as Record<string, unknown>;
+				if (typeof parsed.capUsd === "number" && parsed.capUsd > 0) {
+					capUsd = parsed.capUsd;
+				}
+			} catch {
+				// fall through to validation error below
+			}
+			if (capUsd === null) {
+				res.writeHead(400, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ ok: false, error: "capUsd must be > 0" }));
+				return;
+			}
+			this.currentCapUsd = capUsd;
+			this.onBudgetExtended?.(capUsd);
+			// Lift the pause if the new cap is above what has been spent.
+			if (this.budgetPaused && capUsd > this.accumulator.totalCostUsd()) {
+				this.budgetPaused = false;
+				if (this.budgetResolve) {
+					this.budgetResolve();
+					this.budgetResolve = null;
+				}
+				this.push("cost-resumed", { newCapUsd: capUsd, budgetPaused: false });
+			}
+			console.log(`[monitor] Budget cap set to $${capUsd.toFixed(2)}`);
+			this.push("status", this.statusPayload());
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: true, newCapUsd: capUsd }));
+			return;
+		}
+
+		// ── POST /pause-agent — halt one agent at the next dispatch boundary
+		if (url === "/pause-agent" && req.method === "POST") {
+			const agentId = await this.readAgentId(req, res);
+			if (agentId === null) return;
+			this.pausedAgents.add(agentId);
+			console.log(`[monitor] Agent "${agentId}" paused`);
+			this.push("agent-paused", { agentId });
+			this.push("status", this.statusPayload());
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: true, paused: [...this.pausedAgents] }));
+			return;
+		}
+
+		// ── POST /resume-agent — lift a per-agent pause
+		if (url === "/resume-agent" && req.method === "POST") {
+			const agentId = await this.readAgentId(req, res);
+			if (agentId === null) return;
+			this.pausedAgents.delete(agentId);
+			console.log(`[monitor] Agent "${agentId}" resumed`);
+			this.push("agent-resumed", { agentId });
+			this.push("status", this.statusPayload());
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: true, paused: [...this.pausedAgents] }));
+			return;
+		}
+
 		// ── POST /stop
 		if (url === "/stop" && req.method === "POST") {
 			res.writeHead(200, { "Content-Type": "application/json" });
@@ -912,6 +984,41 @@ export class MonitorServer {
 
 	// ── Change stream watchers ────────────────────────────────────────────────
 
+	/**
+	 * Parse and validate an `agentId` from a POST body for the pause/resume
+	 * endpoints. Writes a 400 response and returns null when the body is malformed
+	 * or names an agent not in this mission's team — so a stray id can never
+	 * silently create a phantom pause entry.
+	 */
+	private async readAgentId(
+		req: IncomingMessage,
+		res: ServerResponse,
+	): Promise<string | null> {
+		const body = await readBody(req);
+		let agentId: string | null = null;
+		try {
+			const parsed = JSON.parse(body) as Record<string, unknown>;
+			if (typeof parsed.agentId === "string" && parsed.agentId.trim()) {
+				agentId = parsed.agentId.trim();
+			}
+		} catch {
+			// fall through to 400 below
+		}
+		if (agentId === null) {
+			res.writeHead(400, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: false, error: "agentId required" }));
+			return null;
+		}
+		if (!this.agents.some((a) => a.id === agentId)) {
+			res.writeHead(404, { "Content-Type": "application/json" });
+			res.end(
+				JSON.stringify({ ok: false, error: `unknown agent "${agentId}"` }),
+			);
+			return null;
+		}
+		return agentId;
+	}
+
 	private async watchMailbox(): Promise<void> {
 		let backoffMs = 1_000;
 		while (true) {
@@ -1030,6 +1137,7 @@ export class MonitorServer {
 			started: this.started,
 			stepEnabled: this.stepEnabled,
 			running: [...this.runningAgents],
+			pausedAgents: [...this.pausedAgents],
 			missionTotalUsd: this.accumulator.totalCostUsd(),
 			maxCostUsd: this.currentCapUsd,
 			budgetPaused: this.budgetPaused,

--- a/packages/control-plane/src/copilot-router.ts
+++ b/packages/control-plane/src/copilot-router.ts
@@ -15,7 +15,7 @@ import { parseTeamConfig } from "@magi/agent-config";
 import { createMongoMailboxRepository } from "@magi/agent-runtime-worker";
 import type { Request, Response, Router } from "express";
 import { Router as createRouter } from "express";
-import { type Db, ObjectId } from "mongodb";
+import { type Collection, type Db, ObjectId } from "mongodb";
 import {
 	type CopilotDaemonHandle,
 	startCopilotDaemon,
@@ -559,6 +559,31 @@ async function executeAction(
 			return `Scheduled message created for mission "${missionId}"`;
 		}
 
+		case "pause_agent":
+		case "resume_agent": {
+			const missionId = payload.missionId as string;
+			const agentId = payload.agentId as string;
+			const endpoint =
+				action.type === "pause_agent" ? "/pause-agent" : "/resume-agent";
+			await postToMissionMonitor(missions, userId, missionId, endpoint, {
+				agentId,
+			});
+			const verb = action.type === "pause_agent" ? "paused" : "resumed";
+			return `Agent "${agentId}" ${verb} in mission "${missionId}"`;
+		}
+
+		case "set_mission_budget": {
+			const missionId = payload.missionId as string;
+			const capUsd = payload.capUsd as number;
+			if (typeof capUsd !== "number" || capUsd <= 0) {
+				throw new Error("set_mission_budget requires a positive capUsd");
+			}
+			await postToMissionMonitor(missions, userId, missionId, "/set-budget", {
+				capUsd,
+			});
+			return `Mission "${missionId}" spending cap set to $${capUsd.toFixed(2)}`;
+		}
+
 		default:
 			throw new Error(`Unknown action type "${action.type}"`);
 	}
@@ -569,6 +594,40 @@ async function executeAction(
 // ---------------------------------------------------------------------------
 
 type TeamFile = { path: string; content: string };
+
+/**
+ * POST a JSON body to a mutating endpoint on a mission's execution-plane monitor
+ * server (port 4000), scoped to the requesting user and authenticated with the
+ * per-mission monitor token. Throws if the mission is unknown to the user, has
+ * no private IP (not running), or the monitor returns non-2xx.
+ */
+async function postToMissionMonitor(
+	missions: Collection<MissionDoc>,
+	userId: string,
+	missionId: string,
+	endpoint: string,
+	body: unknown,
+): Promise<void> {
+	const mission = await missions.findOne({ missionId, userId });
+	if (!mission?.privateIp) {
+		throw new Error(
+			`Mission "${missionId}" is not running (no private IP) — cannot ${endpoint}`,
+		);
+	}
+	const token = deriveMonitorToken(missionId);
+	const res = await fetch(`http://[${mission.privateIp}]:4000${endpoint}`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(token ? { "x-monitor-token": token } : {}),
+		},
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(15_000),
+	});
+	if (!res.ok) {
+		throw new Error(`Monitor ${endpoint} failed: HTTP ${res.status}`);
+	}
+}
 
 /**
  * Recursively read a mission's sharedDir via the monitor server and return a

--- a/packages/control-plane/src/copilot-tools.ts
+++ b/packages/control-plane/src/copilot-tools.ts
@@ -417,7 +417,10 @@ export function createCopilotTools(
 			"- restore_template_version: { templateId, version } — roll back a template to an archived version (archives current state first)\n" +
 			"- save_session_config: { missionId, teamConfigYaml, teamFiles?: [{path, content}], mentalMaps?: {[agentId]: html} }\n" +
 			"- cancel_schedule: { id }\n" +
-			"- create_schedule: { missionId, to, subject, body, cron?, deliverAt?, label? }",
+			"- create_schedule: { missionId, to, subject, body, cron?, deliverAt?, label? }\n" +
+			"- pause_agent: { missionId, agentId } — halt one agent at its next dispatch boundary (e.g. a runaway flagged by a limit alert)\n" +
+			"- resume_agent: { missionId, agentId } — lift a previous pause\n" +
+			"- set_mission_budget: { missionId, capUsd } — set the mission's absolute spending cap in USD",
 		parameters: Type.Object({
 			type: Type.String({ description: "Action type (see description)" }),
 			label: Type.String({
@@ -446,6 +449,9 @@ export function createCopilotTools(
 				"save_session_config",
 				"cancel_schedule",
 				"create_schedule",
+				"pause_agent",
+				"resume_agent",
+				"set_mission_budget",
 			]);
 			if (!VALID_TYPES.has(type)) {
 				return err(


### PR DESCRIPTION
Corrective re-merge: PR #12 was accidentally merged into `sprint24-stats-collector` instead of `main` (a base-branch edit silently failed), so phase 4 never reached main. This PR targets `main` directly. Diff is phase 4 only.

Copilot intervention tools (OODA "Act"): per-agent pause gate + `/pause-agent`/`/resume-agent`/`/set-budget` monitor endpoints, `isAgentPaused` wired in the daemon, `pause_agent`/`resume_agent`/`set_mission_budget` copilot ProposeAction types via `postToMissionMonitor`, and dashboard `limit-alert` toasts. See implementation-history "Sprint 24 (Phase 4)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)